### PR TITLE
Prefer plaintext over html of all the mail multiparts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*~
+*.pyc
+config.xml
+mailerror.log
+*.pid

--- a/config.py
+++ b/config.py
@@ -27,3 +27,6 @@ watchDir = "~/Maildir/new/"
 
 domains = []
 fallbackToJid = ''
+
+# 'plaintext' or 'html2text' or 'html'
+preferredFormat = 'plaintext'

--- a/config_example.xml
+++ b/config_example.xml
@@ -57,6 +57,9 @@
         <map>jabber.localhost=jabber.mail.localhost</map>
     </domains>
 
+    <!-- Preferred format: plaintext or html2text or html -->
+    <preferredFormat>plaintext</preferredFormat>
+
     <!-- JID to use when actual recipient is not found (for personal use /
       maillist problem fix -->
     <!--<fallbackToJid>me@jabber.localhost</fallbackToJid>-->


### PR DESCRIPTION
Configurable.

I had my suspicions, but only found examples today: sometimes, the text/plain part of the message is worse (less useful/informative/readable) than html2text'd version of the html part of the message. The example I found has the text/plain part contain the same html as the html part, except it, of course, doesn't get processed with html2text. 
